### PR TITLE
Improve search

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -35,7 +35,7 @@ int negamax(thrawn::Position* pos, ThreadData* td, int depth, int alpha, int bet
     int static_eval = 0;
 
     // init local pv
-    td->pv_depth[pos->ply] = pos->ply;
+    td->pv_length[pos->ply] = pos->ply;
 
     // 1) Check repetition or 50-move draw
     if (pos->ply && isRepetition(pos) || pos->fifty_move >= 100)
@@ -325,11 +325,11 @@ full_search:
 
             // Update PV
             td->pv_table[pos->ply][pos->ply] = move;
-            for (int nextPly = pos->ply + 1; nextPly < td->pv_depth[pos->ply + 1]; nextPly++)
+            for (int nextPly = pos->ply + 1; nextPly < td->pv_length[pos->ply + 1]; nextPly++)
             {
                 td->pv_table[pos->ply][nextPly] = td->pv_table[pos->ply + 1][nextPly];
             }
-            td->pv_depth[pos->ply] = td->pv_depth[pos->ply + 1];
+            td->pv_length[pos->ply] = td->pv_length[pos->ply + 1];
 
             // Fail-hard beta cutoff
             if (alpha >= beta)

--- a/src/search.h
+++ b/src/search.h
@@ -57,4 +57,8 @@ void quicksort_moves(std::vector<int> &moves,
 int futility_margin(int depth);
 int futility_move_count(int depth);
 
+// some search constants
+static const int WindowDepth   = 4;
+static const int WindowSize    = 10;
+
 #endif // SEARCH_H

--- a/src/threading.cpp
+++ b/src/threading.cpp
@@ -15,7 +15,7 @@ static int globalSearchStartTime = 0;
  * Initializes all fixed‑size arrays to zero and sets flags.
  */
 ThreadData::ThreadData() {
-    pv_depth.fill(0);
+    pv_length.fill(0);
     for (auto &row : pv_table)
         row.fill(0);
     for (auto &row : killer_moves)
@@ -28,13 +28,16 @@ ThreadData::ThreadData() {
     allowNullMovePruning = true;
 
     nodes = 0;
+
+    final_depth = 0;
+    final_score = 0;
 }
 
 /*
  * Reset the thread data between searches.
  */
 void ThreadData::resetThreadData() {
-    pv_depth.fill(0);
+    pv_length.fill(0);
     for (auto &row : pv_table)
         row.fill(0);
     for (auto &row : killer_moves)
@@ -47,6 +50,9 @@ void ThreadData::resetThreadData() {
     allowNullMovePruning = true;
 
     nodes = 0;
+
+    final_depth = 0;
+    final_score = 0;
 }
 
 /**
@@ -67,8 +73,10 @@ void smp_worker_thread_func(thrawn::Position pos, int threadID, int maxDepth)
         if (stopped == 1)
             break;
         
-        if (threadID == 0)
-            td->follow_pv_flag = true;
+        td->follow_pv_flag = true;
+
+        std::array<int, MAX_DEPTH> backup_pv = td->pv_table[0];
+        int backup_pv_length = td->pv_length[0];
         
         // Perform the search at the current depth.
         score = negamax(&pos, td, curr_depth, alpha, beta);
@@ -76,6 +84,8 @@ void smp_worker_thread_func(thrawn::Position pos, int threadID, int maxDepth)
         // If the score falls outside the aspiration window, widen the window and continue.
         if ((score <= alpha) || (score >= beta))
         {
+            td->pv_table[0] = backup_pv;
+            td->pv_length[0] = backup_pv_length;
             alpha = -INFINITY;
             beta = INFINITY;
             continue;
@@ -84,13 +94,16 @@ void smp_worker_thread_func(thrawn::Position pos, int threadID, int maxDepth)
         // Update the aspiration window.
         alpha = score - 50;
         beta = score + 50;
+
+        td->final_depth = curr_depth;
+        td->final_score = score;
         
-        // Always print an info line from the master thread (thread 0)
+        // print an info line from the master thread (thread 0)
         if (threadID == 0)
         {   
             int currentTime = get_time_ms() - globalSearchStartTime;
             std::cout << "info depth " << curr_depth
-                      << " nodes " << td->nodes
+                      << " nodes " << total_nodes
                       << " time " << currentTime;
             
             // Determine whether to report a mate score or a centipawn score.
@@ -108,10 +121,10 @@ void smp_worker_thread_func(thrawn::Position pos, int threadID, int maxDepth)
             }
             
             // Print the principal variation if it exists; otherwise print a default message.
-            if (td->pv_depth[0] > 0)
+            if (td->pv_length[0] > 0)
             {
                 std::cout << " pv ";
-                for (int i = 0; i < td->pv_depth[0]; i++)
+                for (int i = 0; i < td->pv_length[0]; i++)
                 {
                     print_move(td->pv_table[0][i]);
                     std::cout << " ";
@@ -123,19 +136,8 @@ void smp_worker_thread_func(thrawn::Position pos, int threadID, int maxDepth)
             }
             
             std::cout << "\n";
-            std::cout.flush();  // Ensure immediate output
+            std::cout.flush();
         }
-    }
-    
-    // When the search is complete, the master thread prints the best move.
-    if (threadID == 0)
-    {
-        std::cout << "total nodes across all threads " << total_nodes << std::endl;
-        std::cout << "bestmove ";
-        print_move(td->pv_table[0][0]);
-        std::cout << "\n";
-        std::cout.flush();
-        stopped = 1;
     }
 }
 
@@ -173,80 +175,77 @@ void search_position_threaded(thrawn::Position* rootPos, int maxDepth, int numTh
     {
         workerPool[i].join();
     }
+
+    // After all threads have finished, select the best result.
+    ThreadData* best_td = select_best_thread(threadDatas, numThreads);
+    
+    // Print the total nodes and best move.
+    //std::cout << "total nodes across all threads " << total_nodes << std::endl;
+    std::cout << "bestmove ";
+    print_move(best_td->pv_table[0][0]);
+    std::cout << "\n";
+    std::cout.flush();
 }
 
-void search_pos_single(thrawn::Position* pos, int depth)
-{
-    
-    ThreadData* td = new ThreadData();
-    total_nodes = 0;
-    stopped = 0;
-    int score = 0;
-    int alpha = -INFINITY;
-    int beta = INFINITY;
-    
-    int start = get_time_ms();
-
-    // iterative deepening
-    for (int curr_depth = 1; curr_depth <= depth; curr_depth++)
-    {
-        // time is up
-        if (stopped == 1)
+/**
+ * select_best_thread
+ * Choose the best result among the threadDatas (mimics Ethereal’s select_from_threads).
+ *
+ * A thread is considered better than another if:
+ *   [1] They have equal depth and the thread’s score is higher.
+ *   [2] The thread has a mate score (i.e. its absolute score is greater than mateScore) and a better mate proximity.
+ *   [3] The thread has a greater depth and (a higher score or the current best isn’t a mate score).
+ */
+ThreadData* select_best_thread(ThreadData threadDatas[], int numThreads) {
+    ThreadData* best_td = &threadDatas[0];
+    int res_thread_id = 0;
+    for (int i = 1; i < numThreads; i++) {
+        int best_depth = best_td->final_depth;
+        int best_score = best_td->final_score;
+        int this_depth = threadDatas[i].final_depth;
+        int this_score = threadDatas[i].final_score;
+        
+        if ((this_depth == best_depth && this_score > best_score)
+            || (std::abs(this_score) > mateScore && std::abs(this_score) > std::abs(best_score))
+            || (this_depth > best_depth && (this_score > best_score || std::abs(best_score) < mateScore)))
         {
-            break;
+            best_td = &threadDatas[i];
+            res_thread_id = i;
         }
-
-        td->follow_pv_flag = true;
-        score = negamax(pos, td, curr_depth, alpha, beta);
-
-        // aspiration window
-        if ((score <= alpha) || (score >= beta))
-        {
-            alpha = -INFINITY;
-            beta = INFINITY;
-            continue;
-        }
-
-        // set up the window for the next iteration
-        alpha = score - 50;
-        beta = score + 50;
-
-        // if pv exist
-        if (td->pv_depth[0])
-        {
-            if (score > -mateVal && score < -mateScore)
-                std::cout << "info score mate " << -(score + mateVal) / 2 - 1
-                          << " depth " << curr_depth
-                          << " nodes " << total_nodes
-                          << " time " << static_cast<unsigned int>(get_time_ms() - start)
-                          << " pv ";
-            else if (score > mateScore && score < mateVal)
-                std::cout << "info score mate " << (mateVal - score) / 2 + 1
-                          << " depth " << curr_depth
-                          << " nodes " << total_nodes
-                          << " time " << static_cast<unsigned int>(get_time_ms() - start)
-                          << " pv ";
-            else
-                std::cout << "info score cp " << score
-                          << " depth " << curr_depth
-                          << " nodes " << total_nodes
-                          << " time " << static_cast<unsigned int>(get_time_ms() - start)
-                          << " pv ";
-
-            for (int i = 0; i < td->pv_depth[0]; i++)
-            {
-                print_move(td->pv_table[0][i]);
-                std::cout << " ";
-            }
-            std::cout << "\n";
-        }
-
-        std::cout<<"ply: "<<total_nodes<<endl;
     }
 
-    std::cout << "bestmove ";
-    print_move(td->pv_table[0][0]);
-    std::cout << "\n";
+    // the case where the best thread is not the main thread (thread 0)
+    if(best_td!=&threadDatas[0])
+    {   
+        std::cout<<"thread "<<res_thread_id<<" is better"<<"\n";
+        int currentTime = get_time_ms() - globalSearchStartTime;
+        std::cout << "info depth " << best_td->final_depth
+                  << " nodes " << total_nodes
+                  << " time " << currentTime
+                  << " score ";
 
-    stopped = 1; // fixes zero eval blundering bug
+        // Print mate or centipawn score
+        if (best_td->final_score > mateScore) {
+            std::cout << "mate " << (mateVal - best_td->final_score) / 2 + 1;
+        } else if (best_td->final_score < -mateScore) {
+            std::cout << "mate " << -(best_td->final_score + mateVal) / 2 - 1;
+        } else {
+            std::cout << "cp " << best_td->final_score;
+        }
+
+        // Print the principal variation (PV)
+        if (best_td->pv_length[0] > 0) {
+            std::cout << " pv ";
+            for (int i = 0; i < best_td->pv_length[0]; i++) {
+                print_move(best_td->pv_table[0][i]);
+                std::cout << " ";
+            }
+        } else {
+            std::cout << " pv (none)";
+        }
+
+        std::cout << "\n";
+        std::cout.flush();
+    }
+    return best_td;
 }

--- a/src/threading.h
+++ b/src/threading.h
@@ -9,7 +9,7 @@
 class ThreadData {
 public:
     // PV storage: one array for PV lengths and a 2D array for the PV lines.
-    std::array<int, MAX_DEPTH> pv_depth;
+    std::array<int, MAX_DEPTH> pv_length;
     std::array<std::array<int, MAX_DEPTH>, MAX_DEPTH> pv_table;
 
     // Killer moves and history moves.
@@ -23,6 +23,9 @@ public:
 
     long long nodes;
 
+    int final_depth;
+    int final_score;
+
     // Constructor initializes all arrays to zero and flags to false (or true where needed).
     ThreadData();
 
@@ -35,7 +38,6 @@ void smp_worker_thread_func(thrawn::Position pos, int threadID, int maxDepth);
 // search position entry point
 void search_position_threaded(thrawn::Position* pos, int depth, int numThreads);
 
-// for testing purposes
-void search_pos_single(thrawn::Position* pos, int depth);
+ThreadData* select_best_thread(ThreadData threadDatas[], int numThreads);
 
 #endif // THREADING_H

--- a/src/transposition_table.h
+++ b/src/transposition_table.h
@@ -6,9 +6,10 @@
 
 // Constants for the tt->
 static const int no_hashmap_entry = 100000;  // Sentinel for "TT miss"
-static const int hashFlagEXACT    = 0;
-static const int hashFlagALPHA    = 1;
-static const int hashFlagBETA     = 2;
+static const int BOUND_NONE       = 0;
+static const int BOUND_LOWER      = 1;
+static const int BOUND_UPPER      = 2;
+static const int BOUND_EXACT      = 3;
 
 struct TTEntry 
 {
@@ -38,11 +39,10 @@ public:
     void incrementAge() { currentAge++; }
 
     // Lookup a position in the tt
-    int probe(const thrawn::Position* pos, int depth, int alpha, int beta,
-              int &bestMove, int ply);
+    bool probe(const thrawn::Position* pos, int& depth, int alpha, int beta, int& bestMove, int& score, int& flag);
 
     // Store an entry in the tt
-    void store(const thrawn::Position* pos, int depth, int score, int flag, int bestMove, int ply);
+    void store(const thrawn::Position* pos, int depth, int score, int flag, int bestMove);
     
     uint64_t encodeTTData(int bestMove, int depth, int score, int hash_flag);
 


### PR DESCRIPTION
Results of Thrawn_tt vs Thrawn_2.1 (60+1, 4t - NULL, 256MB - 128MB, popularpos_lichess.epd):
Elo: 98.07 +/- 31.08, nElo: 160.64 +/- 48.15
LOS: 100.00 %, DrawRatio: 38.00 %, PairsRatio: 5.89
Games: 200, Wins: 71, Losses: 16, Draws: 113, Points: 127.5 (63.75 %)
Ptnml(0-2): [1, 8, 38, 41, 12], WL/DD Ratio: 0.19

# Changes
- Aggregate thread results and select the best one  
- Improve stability of aspiration window  
- New transposition table (TT) logic in search  

## Aspiration Window
- **Constants:** `WindowDepth`, `WindowSize`  
- For depths < `WindowDepth`: use a wide window  
- For depths ≥ `WindowDepth`: center window around previous best score, width = `WindowSize`  

### Aspiration Loop
- If score falls outside the window → adaptively widen/narrow window by adjusting delta and shifting alpha/beta 
- **Fail-low:** lower alpha and beta  
- **Fail-high:** increase beta
- Backup previous principal variation (PV) before search; restore PV on failure to prevent broken lines  

**Results:**  
- Fewer failed searches outside window  
- Reduced wasted computation  
- PV protected from overwrites by failed searches  

## TT Logic

### Unified Bound Flags
- New flags:  
  - `BOUND_NONE`  
  - `BOUND_LOWER`  
  - `BOUND_UPPER`  
  - `BOUND_EXACT`  
- Allow precise control over stored/retrieved bound types  

### TT API Refactor
- `probe()`: returns boolean, outputs depth, bestMove, score, flag by reference  
- `store()`: minimal parameters, consistent mate score adjustment  
- Overwrite TT entries only if new entry is an exact bound or of comparable depth  

### Probe Logic
- Check TT entry depth and bound type for pruning:  
  - **Exact:** use score  
  - **Lower bound:** if score ≥ beta → cutoff  
  - **Upper bound:** if score ≤ alpha→ cutoff  
  - Otherwise → search  

### Integration in Search
- TT probe results used for cutoffs on both lower and upper bounds  
- TT move used for move ordering and no-hashmove reduction  
