### PR TITLE
Allocate position object copies on to the heap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.out
 *.app
 *.exe
+Thrawn
 
 # Code Editors
 *.vscode

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -5,7 +5,7 @@
 #include "nnue.h"
 #include "globals.h"
 
-const std::string version = " v3.0";
+const std::string version = " v2.2";
 
 
 void init_all()

--- a/src/threading.h
+++ b/src/threading.h
@@ -33,7 +33,7 @@ public:
     void resetThreadData();
 };
 
-void smp_worker_thread_func(thrawn::Position pos, int threadID, int maxDepth);
+void smp_worker_thread_func(thrawn::Position* pos, int threadID, int maxDepth);
 
 // search position entry point
 void search_position_threaded(thrawn::Position* pos, int depth, int numThreads);


### PR DESCRIPTION
Was testing multithreading on a macos arm machine and the program was crashing even with one thread. I think it had to do with `smp_worker_thread_func()` method taking in the position object by value and not creating the copy properly? Or the position objects are too large to fit on the stack?

It was working on windows x64 which has 8mb reserved. I tried to also set 8mb on macos build but the program was still crashing.

SImple fix was just to allocate all position copies on to the heap.